### PR TITLE
Coffeescript, Free Pascal, Lua, Nim Dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/.DS_Store
+.idea

--- a/coffeescript/Dockerfile
+++ b/coffeescript/Dockerfile
@@ -1,0 +1,4 @@
+FROM codesignal/ubuntu-base:v1.1
+
+#Install CoffeeScript
+RUN npm install -g coffeescript@next

--- a/coffeescript/README.md
+++ b/coffeescript/README.md
@@ -1,0 +1,1 @@
+Coffeescript user code execution environment.

--- a/fpc/Dockerfile
+++ b/fpc/Dockerfile
@@ -1,0 +1,5 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+    && apt-get install -y fpc \
+    && rm -rf /var/lib/apt/lists/*

--- a/fpc/README.md
+++ b/fpc/README.md
@@ -1,0 +1,1 @@
+Free Pascal user code execution environment.

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -1,0 +1,22 @@
+FROM codesignal/ubuntu-base:v1.1
+
+#Install Lua
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    make \
+    libreadline-dev \
+    curl \
+    wget \
+    && curl -R -O http://www.lua.org/ftp/lua-5.3.4.tar.gz \
+    && tar zxf lua-5.3.4.tar.gz \
+    && rm lua-5.3.4.tar.gz \
+    && cd lua-5.3.4 \
+    && make linux install \
+    && wget http://luajit.org/download/LuaJIT-2.0.5.tar.gz \
+    && tar -xvzf LuaJIT-2.0.5.tar.gz \
+    && rm LuaJIT-2.0.5.tar.gz \
+    && cd LuaJIT-2.0.5 \
+    && make \
+    && make install \
+    && apt-get -qq -y remove curl wget \
+    && rm -rf /var/lib/apt/lists/*

--- a/lua/README.md
+++ b/lua/README.md
@@ -1,0 +1,1 @@
+Lua user code execution environment.

--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -1,0 +1,7 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+    && add-apt-repository -y ppa:jonathonf/nimlang \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nim \
+    && rm -rf /var/lib/apt/lists/*

--- a/nim/README.md
+++ b/nim/README.md
@@ -1,0 +1,1 @@
+Nim user code execution environment.


### PR DESCRIPTION
Splitting out a few more languages from the main container, most of these are one liners. 

Added tests over in [this](https://github.com/CodeSignal/coderunner/pull/143) pull request.

Test instructions can be found over [here](https://github.com/CodeSignal/dockerfiles/pull/25), though you'll have to adapt and convert `codesignal/typescript:v1.1` and `typescript` to `codesignal/coffeescript:v1.1` and `coffeescript`, and repeat for `lua`, `pas`, and `nim`.