### PR TITLE
Typescript 

### DIFF
--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,0 +1,5 @@
+RUN codesignal/ubuntu-base:v1.1
+
+#Install TypeScript
+# For @types/node@9.6.7 see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342
+RUN npm install -g typescript @types/node@9.6.7

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,4 +1,4 @@
-RUN codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v1.1
 
 #Install TypeScript
 # For @types/node@9.6.7 see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,1 @@
+Typescript user code execution environment.


### PR DESCRIPTION
Moves out the typescript language into a new docker container. 

Included an additional test for the "add" request, which includes all of our request language template from the main app. That can be found over [here](https://github.com/CodeSignal/coderunner/pull/142).

## To Test:
- On a coderunner VM, checkout the `dockerfiles` repo at this branch
- `cd` in to the directory containing the new container, which in this case should be `/path/to/repo/typescript
- Build the container locally, `docker build -t codesignal/typescript:v1.1 .` (The trailing dot tells docker to look for `Dockerfile` in the current directory.
(Sometimes `docker` has trouble with connecting to the internet, this can be resolve by restarting the service with `service docker restart`. I have to do this quite frequently, it's a curious thing)
- Go over to the `coderunner` repo and set the `vm` for the language. This is done by editing the language (in this case `ts`) field in `API/src/compilers.js` to target the VM (`codesignal/typescript:v1.1`).
- If you're testing things from `rundash` on your local coderunner, you should be able to target `raw/ts` to test typescript, and there should be two tests (if you've checked out the coderunner above, which includes a second test for Typescript). Both tests should pass!
- In looking at the `console.log` output of the coderunner server, you should see the docker command for the run request target the new VM, so somewhere in that output you should find `codesignal/typescript:v1.1`