### PR TITLE
Split out (almost) all the other languages

### DIFF
--- a/cs/Dockerfile
+++ b/cs/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
        mono-xsp4 \
        mono-xsp4-base \
        mono-complete \
+       mono-vbnc \
        ca-certificates-mono \
        fsharp \
     && rm -rf /var/lib/apt/lists/*

--- a/cs/README.md
+++ b/cs/README.md
@@ -1,1 +1,3 @@
-User code execution environment for both C# and F#.
+User code execution environment for C#, F#, and Visual Basic.
+
+Visual Basic support provided by the `mono-vbnc` package.

--- a/dart/Dockerfile
+++ b/dart/Dockerfile
@@ -1,0 +1,20 @@
+FROM codesignal/ubuntu-base:v1.1
+
+#Install Dart 1.24.2
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+# Enable HTTPS for apt.
+    apt-transport-https \
+    curl \
+# Get the Google Linux package signing key.
+    && curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+# Set up the location of the stable repository.
+    && curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends dart=1.24.2-1 \
+# Cleanup
+    && apt-get remove -qq -y curl apt-transport-https \
+    && rm -rf /var/lib/apt/lists/*
+
+
+

--- a/dart/README.md
+++ b/dart/README.md
@@ -1,0 +1,1 @@
+Dart user code execution environment.

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-erlang:v1.1
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends elixir \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-erlang:v1.1
+FROM codesignal/erlang:v1.1
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends elixir \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,0 +1,5 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends elixir \
+  && rm -rf /var/lib/apt/lists/*

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,0 +1,1 @@
+Elixir user code execution environment.

--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update \
     && dpkg -i erlang-solutions_1.0_all.deb \
     && apt-get update \
 #Install Erland and High-Performance Erlang Project compiler
-    && apt-get install -y --force-yes erlang erlang-base-hipe \
-    && apt-get install -y erlang-base-hipe \
+    && apt-get install -y --force-yes --no-install-recommends erlang erlang-base-hipe \
 # Cleanup
     && apt-get remove -qq -y wget \
     && rm erlang-solutions_1.0_all.deb \

--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -1,0 +1,15 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
+    && dpkg -i erlang-solutions_1.0_all.deb \
+    && apt-get update \
+#Install Erland and High-Performance Erlang Project compiler
+    && apt-get install -y --force-yes erlang erlange-base-hipe \
+    && apt-get install -y erlang-base-hipe \
+# Cleanup
+    && apt-get remove -qq -y wget \
+    && rm erlang-solutions_1.0_all.deb \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && dpkg -i erlang-solutions_1.0_all.deb \
     && apt-get update \
 #Install Erland and High-Performance Erlang Project compiler
-    && apt-get install -y --force-yes erlang erlange-base-hipe \
+    && apt-get install -y --force-yes erlang erlang-base-hipe \
     && apt-get install -y erlang-base-hipe \
 # Cleanup
     && apt-get remove -qq -y wget \

--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && dpkg -i erlang-solutions_1.0_all.deb \
     && apt-get update \
 #Install Erland and High-Performance Erlang Project compiler
-    && apt-get install -y --force-yes --no-install-recommends erlang erlang-base-hipe \
+    && apt-get install -y --no-install-recommends erlang erlang-base-hipe \
 # Cleanup
     && apt-get remove -qq -y wget \
     && rm erlang-solutions_1.0_all.deb \

--- a/erlang/README.md
+++ b/erlang/README.md
@@ -1,0 +1,1 @@
+Erlang user code execution environment.

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,21 +1,17 @@
 FROM codesignal/java:v1.1
 
+ENV GROOVY_VERSION 2.4.15
+
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends groovy2 \
+  && apt-get install -y --no-install-recommends wget unzip \
+  && cd /tmp \
+  && wget http://dl.bintray.com/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip \
+  && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
+  && mv groovy-${GROOVY_VERSION} /opt/groovy \
+  && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
+# Cleanup
+  && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
-# ENV GROOVY_VERSION 2.4.15
-
-# RUN apt-get update \
-#   && apt-get install -y --no-install-recommends wget unzip \
-#   && cd /tmp \
-#   && wget http://dl.bintray.com/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip \
-#   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
-#   && mv groovy-${GROOVY_VERSION} /opt/groovy \
-#   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
-# # Cleanup
-#   && apt-get remove -qq -y wget unzip \
-#   && rm -rf /var/lib/apt/lists/*
-
-# ENV GROOVY_HOME=/opt/groovy \
-#     PATH=$GROOVY_HOME/bin/:$PATH
+ENV GROOVY_HOME=/opt/groovy \
+    PATH=$GROOVY_HOME/bin/:$PATH

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update \
   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
   && mv groovy-${GROOVY_VERSION} /opt/groovy \
   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
-# Cleanup, having some issues with held packages so calling update again to resolve them
-  && apt-get update \
+# Cleanup, having some issues with held packages so calling autoremove to resolve them
+  && apt-get autoremove \
   && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -9,10 +9,10 @@ RUN apt-get update \
   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
   && mv groovy-${GROOVY_VERSION} /opt/groovy \
   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
-# Cleanup, having some issues with held packages so calling autoremove and autoclean to resolve them
-  && apt-get autoclean \
-  && apt-get autoremove \
-  && apt-get remove -qq -y wget unzip \
+# Skipping Cleanup, having some issues with held packages 
+  # && apt-get autoclean \
+  # && apt-get autoremove \
+  # && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV GROOVY_HOME=/opt/groovy \

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update \
   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
   && mv groovy-${GROOVY_VERSION} /opt/groovy \
   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
-# Cleanup
+# Cleanup, having some issues with held packages so calling update again to resolve them
+  && apt-get update \
   && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update \
   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
   && mv groovy-${GROOVY_VERSION} /opt/groovy \
   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
-# Cleanup, having some issues with held packages so calling autoremove to resolve them
+# Cleanup, having some issues with held packages so calling autoremove and autoclean to resolve them
+  && apt-get autoclean \
   && apt-get autoremove \
   && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get update \
   # && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
-ENV GROOVY_HOME=/opt/groovy \
-    PATH=$GROOVY_HOME/bin/:$PATH
+ENV GROOVY_HOME=/opt/groovy
+ENV PATH=$GROOVY_HOME/bin/:$PATH

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,17 +1,21 @@
 FROM codesignal/java:v1.1
 
-ENV GROOVY_VERSION 2.4.15
-
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget unzip \
-  && cd /tmp \
-  && wget http://dl.bintray.com/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip \
-  && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
-  && mv groovy-${GROOVY_VERSION} /opt/groovy \
-  && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
-# Cleanup
-  && apt-get remove -qq -y wget unzip \
+  && apt-get install -y --no-install-recommends groovy2 \
   && rm -rf /var/lib/apt/lists/*
 
-ENV GROOVY_HOME=/opt/groovy \
-    PATH=$GROOVY_HOME/bin/:$PATH
+# ENV GROOVY_VERSION 2.4.15
+
+# RUN apt-get update \
+#   && apt-get install -y --no-install-recommends wget unzip \
+#   && cd /tmp \
+#   && wget http://dl.bintray.com/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip \
+#   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
+#   && mv groovy-${GROOVY_VERSION} /opt/groovy \
+#   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
+# # Cleanup
+#   && apt-get remove -qq -y wget unzip \
+#   && rm -rf /var/lib/apt/lists/*
+
+# ENV GROOVY_HOME=/opt/groovy \
+#     PATH=$GROOVY_HOME/bin/:$PATH

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -9,10 +9,6 @@ RUN apt-get update \
   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
   && mv groovy-${GROOVY_VERSION} /opt/groovy \
   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
-# Skipping Cleanup, having some issues with held packages 
-  # && apt-get autoclean \
-  # && apt-get autoremove \
-  # && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV GROOVY_HOME=/opt/groovy

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -3,14 +3,14 @@ FROM codesignal/ubuntu-base:v1.1
 ENV GROOVY_VERSION 2.4.15
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget unzip \
   && cd /tmp \
   && wget http://dl.bintray.com/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip \
   && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
   && mv groovy-${GROOVY_VERSION} /opt/groovy \
   && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
 # Cleanup
-  && apt-get remove -qq -y wget \
+  && apt-get remove -qq -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV GROOVY_HOME=/opt/groovy \

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/java:v1.1
 
 ENV GROOVY_VERSION 2.4.15
 

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,0 +1,17 @@
+FROM codesignal/ubuntu-base:v1.1
+
+ENV GROOVY_VERSION 2.4.15
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends wget \
+  && cd /tmp \
+  && wget http://dl.bintray.com/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip \
+  && unzip apache-groovy-binary-${GROOVY_VERSION}.zip \
+  && mv groovy-${GROOVY_VERSION} /opt/groovy \
+  && rm apache-groovy-binary-${GROOVY_VERSION}.zip \
+# Cleanup
+  && apt-get remove -qq -y wget \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV GROOVY_HOME=/opt/groovy \
+    PATH=$GROOVY_HOME/bin/:$PATH

--- a/groovy/README.md
+++ b/groovy/README.md
@@ -1,0 +1,1 @@
+Groovy user code execution environment.

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,0 +1,21 @@
+FROM codesignal/ubuntu-base:v1.1
+
+#Install Julia 0.6.2, from https://github.com/docker-library/julia/blob/master/Dockerfile
+ENV JULIA_PATH=/usr/local/julia \
+    JULIA_VERSION=0.6.2
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && mkdir $JULIA_PATH \
+  && curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o julia.tar.gz \
+  && curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz.asc" -o julia.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 3673DF529D9049477F76B37566E3C7DC03D6E495 \
+  && gpg --batch --verify julia.tar.gz.asc julia.tar.gz \
+  && rm -r "$GNUPGHOME" julia.tar.gz.asc \
+  && tar -xzf julia.tar.gz -C $JULIA_PATH --strip-components 1 \
+# Cleanup
+  && apt-get remove -qq -y curl \
+  && rm -rf /var/lib/apt/lists/* julia.tar.gz*
+
+ENV PATH $JULIA_PATH/bin:$PATH

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -3,7 +3,7 @@ FROM codesignal/ubuntu-base:v1.1
 #Install Julia 0.6.2, from https://github.com/docker-library/julia/blob/master/Dockerfile
 RUN JULIA_PATH=/usr/local/julia \
     JULIA_VERSION=0.6.2 ;\
-  && apt-get update \
+  apt-get update \
   && apt-get install -y --no-install-recommends curl \
   && mkdir $JULIA_PATH \
   && curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o julia.tar.gz \

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,10 +1,9 @@
 FROM codesignal/ubuntu-base:v1.1
 
 #Install Julia 0.6.2, from https://github.com/docker-library/julia/blob/master/Dockerfile
-ENV JULIA_PATH=/usr/local/julia \
-    JULIA_VERSION=0.6.2
-
-RUN apt-get update \
+RUN JULIA_PATH=/usr/local/julia \
+    JULIA_VERSION=0.6.2 ;\
+  && apt-get update \
   && apt-get install -y --no-install-recommends curl \
   && mkdir $JULIA_PATH \
   && curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o julia.tar.gz \
@@ -18,4 +17,5 @@ RUN apt-get update \
   && apt-get remove -qq -y curl \
   && rm -rf /var/lib/apt/lists/* julia.tar.gz*
 
-ENV PATH $JULIA_PATH/bin:$PATH
+ENV JULIA_PATH=/usr/local/julia \
+    PATH=$JULIA_PATH/bin:$PATH

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -17,5 +17,5 @@ RUN JULIA_PATH=/usr/local/julia \
   && apt-get remove -qq -y curl \
   && rm -rf /var/lib/apt/lists/* julia.tar.gz*
 
-ENV JULIA_PATH=/usr/local/julia \
-    PATH=$JULIA_PATH/bin:$PATH
+ENV JULIA_PATH=/usr/local/julia
+ENV PATH=$JULIA_PATH/bin:$PATH

--- a/julia/README.md
+++ b/julia/README.md
@@ -1,0 +1,1 @@
+Julia user code execution environment.

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,0 +1,13 @@
+FROM codesignal/ubuntu-base:v1.1
+
+ENV KOTLIN_VERSION=1.2.40 \
+    KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends zip wget \
+  && wget $KOTLIN_COMPILER_URL -O /tmp/a.zip \
+  && unzip /tmp/a.zip -d /opt  \
+  && rm /tmp/a.zip \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:/opt/kotlinc/bin

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -4,10 +4,11 @@ ENV KOTLIN_VERSION=1.2.40
 ENV KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends zip wget \
+  && apt-get install -y --no-install-recommends zip wget unzip \
   && wget $KOTLIN_COMPILER_URL -O /tmp/a.zip \
   && unzip /tmp/a.zip -d /opt  \
   && rm /tmp/a.zip \
+  && apt-get remove -qq -y unzip wget zip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV PATH $PATH:/opt/kotlinc/bin

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -7,7 +7,8 @@ RUN KOTLIN_VERSION=1.2.40 \
   && wget $KOTLIN_COMPILER_URL -O /tmp/a.zip \
   && unzip /tmp/a.zip -d /opt  \
   && rm /tmp/a.zip \
-  && apt-get remove -qq -y unzip wget zip \
+# Having an issue with apt, skipping cleanup
+  # && apt-get remove -qq -y unzip wget zip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV PATH $PATH:/opt/kotlinc/bin

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,9 +1,8 @@
 FROM codesignal/ubuntu-base:v1.1
 
-ENV KOTLIN_VERSION=1.2.40
-ENV KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip
-
-RUN apt-get update \
+RUN KOTLIN_VERSION=1.2.40 \
+    KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip ; \
+  apt-get update \
   && apt-get install -y --no-install-recommends zip wget unzip \
   && wget $KOTLIN_COMPILER_URL -O /tmp/a.zip \
   && unzip /tmp/a.zip -d /opt  \

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/java:v1.1
 
 RUN KOTLIN_VERSION=1.2.40 \
     KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip ; \

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,9 +1,8 @@
 FROM codesignal/ubuntu-base:v1.1
 
-ENV KOTLIN_VERSION=1.2.40 \
-    KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip
-
-RUN apt-get update \
+RUN KOTLIN_VERSION=1.2.40 \
+    KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip \
+  apt-get update \
   && apt-get install -y --no-install-recommends zip wget \
   && wget $KOTLIN_COMPILER_URL -O /tmp/a.zip \
   && unzip /tmp/a.zip -d /opt  \

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,12 +1,13 @@
 FROM codesignal/ubuntu-base:v1.1
 
-RUN KOTLIN_VERSION=1.2.40 \
-    KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip \
-  apt-get update \
+ENV KOTLIN_VERSION=1.2.40
+ENV KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip
+
+RUN apt-get update \
   && apt-get install -y --no-install-recommends zip wget \
   && wget $KOTLIN_COMPILER_URL -O /tmp/a.zip \
   && unzip /tmp/a.zip -d /opt  \
   && rm /tmp/a.zip \
   && rm -rf /var/lib/apt/lists/*
 
-ENV PATH=$PATH:/opt/kotlinc/bin
+ENV PATH $PATH:/opt/kotlinc/bin

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,0 +1,1 @@
+Kotlin user code execution environment.

--- a/lisp/Dockerfile
+++ b/lisp/Dockerfile
@@ -1,0 +1,16 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  libsigsegv2 \
+  libffcall1 \
+  libreadline5 \
+  wget \
+  && wget http://ftp.debian.org/debian/pool/main///c/clisp/clisp_2.49-8.1_amd64.deb \
+  && dpkg -i clisp_2.49-8.1_amd64.deb \
+  && wget https://beta.quicklisp.org/quicklisp.lisp -P /tmp \
+  && echo "(quicklisp-quickstart:install)\n(ql:add-to-init-file)\n" >> /tmp/quicklisp.lisp \
+  && printf '\n' | clisp /tmp/quicklisp.lisp \
+  && apt-get remove -qq -y wget \
+  && rm clisp_2.49-8.1_amd64.deb \
+  && rm -rf /var/lib/apt/lists/*

--- a/lisp/README.md
+++ b/lisp/README.md
@@ -1,0 +1,1 @@
+Lisp user code execution environment.

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -1,0 +1,9 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    perl \
+    libjson-perl \
+    libdbi-perl \
+    libdbd-mysql-perl \
+    && rm -rf /var/lib/apt/lists/*

--- a/perl/README.md
+++ b/perl/README.md
@@ -1,0 +1,1 @@
+Perl user code execution environment.

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,9 +2,7 @@ FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
-    && mkdir -p /opt/rust \
-    && curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --no-modify-path -y \
-    && chmod -R 777 /opt/rust \
+    && curl https://sh.rustup.rs -sSf | sh -- -y \
 # Cleanup
     && apt-get remove -qq -y curl \
     && rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -3,7 +3,7 @@ FROM codesignal/ubuntu-base:v1.1
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl file \
     && mkdir -p /opt/rust \
-    && curl -sf -L https://static.rust-lang.org/rustup.sh | sh \
+    && curl -sf -L https://static.rust-lang.org/rustup.sh | sh --disable-sudo \
 # Cleanup
     && apt-get remove -qq -y curl file \
     && rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,9 +1,9 @@
 FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl file \
     && mkdir -p /opt/rust \
     && curl -sf -L https://static.rust-lang.org/rustup.sh | sh \
 # Cleanup
-    && apt-get remove -qq -y curl \
+    && apt-get remove -qq -y curl file \
     && rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,10 +1,10 @@
 FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget file \
+    && apt-get install -y --no-install-recommends wget curl file \
     && mkdir -p /opt/rust \
     && wget https://static.rust-lang.org/rustup.sh \
     && /bin/bash ./rustup.sh --disable-sudo \
 # Cleanup
-    && apt-get remove -qq -y wget file \
+    && apt-get remove -qq -y wget curl file \
     && rm -rf /var/lib/apt/lists/* rustup.sh

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -3,8 +3,7 @@ FROM codesignal/ubuntu-base:v1.1
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && mkdir -p /opt/rust \
-    && curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --no-modify-path -y \
-    && chmod -R 777 /opt/rust \
+    && curl -sf -L https://static.rust-lang.org/rustup.sh | sh \
 # Cleanup
     && apt-get remove -qq -y curl \
     && rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -3,7 +3,7 @@ FROM codesignal/ubuntu-base:v1.1
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && mkdir -p /opt/rust \
-    && curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --disable-sudo --no-modify-path -y \
+    && curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --no-modify-path -y \
     && chmod -R 777 /opt/rust \
 # Cleanup
     && apt-get remove -qq -y curl \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,9 +1,10 @@
 FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl file \
+    && apt-get install -y --no-install-recommends wget file \
     && mkdir -p /opt/rust \
-    && curl -sf -L https://static.rust-lang.org/rustup.sh | sh --disable-sudo \
+    && wget https://static.rust-lang.org/rustup.sh \
+    && /bin/bash ./rustup.sh --disable-sudo \
 # Cleanup
-    && apt-get remove -qq -y curl file \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get remove -qq -y wget file \
+    && rm -rf /var/lib/apt/lists/* rustup.sh

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,10 +1,10 @@
 FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget curl file \
+    && apt-get install -y --no-install-recommends curl \
     && mkdir -p /opt/rust \
-    && wget https://static.rust-lang.org/rustup.sh \
-    && /bin/bash ./rustup.sh --disable-sudo \
+    && curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --disable-sudo --no-modify-path -y \
+    && chmod -R 777 /opt/rust \
 # Cleanup
-    && apt-get remove -qq -y wget curl file \
-    && rm -rf /var/lib/apt/lists/* rustup.sh
+    && apt-get remove -qq -y curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,0 +1,10 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && mkdir -p /opt/rust \
+    && curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --no-modify-path -y \
+    && chmod -R 777 /opt/rust \
+# Cleanup
+    && apt-get remove -qq -y curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,7 +2,7 @@ FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
-    && curl https://sh.rustup.rs -sSf | sh -- -y \
+    && curl https://sh.rustup.rs -sSf | sh \
 # Cleanup
     && apt-get remove -qq -y curl \
     && rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,7 +2,14 @@ FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
-    && curl https://sh.rustup.rs -sSf | sh \
+    && mkdir -p /opt/rust \
+    && curl https://sh.rustup.rs -sSf | HOME=/opt/rust sh -s -- --no-modify-path -y \
+    && chmod -R 777 /opt/rust \
 # Cleanup
     && apt-get remove -qq -y curl \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/rust/.cargo/bin:$PATH
+
+# Install default Rust items.
+RUN rustup default stable

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,1 @@
+Rust user code execution environment.

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -13,12 +13,12 @@ RUN  \
     && echo >> /root/.bashrc  \
     && echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc \
 # Install SBT
-    && curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb  \
-    && dpkg -i sbt-$SBT_VERSION.deb  \
-    && rm sbt-$SBT_VERSION.deb  \
-    && apt-get update \
-    && apt-get install sbt  \
-    && sbt sbtVersion \
+    # && curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb  \
+    # && dpkg -i sbt-$SBT_VERSION.deb  \
+    # && rm sbt-$SBT_VERSION.deb  \
+    # && apt-get update \
+    # && apt-get install sbt  \
+    # && sbt sbtVersion \
 # Clean up
     && apt-get remove -qq -y wget curl \
     && rm -rf /var/lib/apt/lists/*

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,12 +1,23 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/java:v1.1
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget java8-runtime-headless \
-    && wget http://www.scala-lang.org/files/archive/scala-2.12.5.deb \
-    && dpkg -i scala-2.12.5.deb \
+ENV SCALA_VERSION=2.12.7 \
+    SBT_VERSION=1.2.6
+
+# Scala Expects this file to exist
+RUN touch /usr/lib/jvm/java-11-openjdk-amd64/release \
     && apt-get update \
-    && apt-get install -y --no-install-recommends scala \
-# Remove deb file and clean up
-    && apt-get remove -qq -y wget \
-    && rm scala-2.15.5.deb \
+    && apt-get install -y --no-install-recommends wget curl \
+# Install Scala, pipe curl into tar.
+    && curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ \
+    && echo >> /root/.bashrc  \
+    && echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc \
+# Install SBT
+    && curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb  \
+    && dpkg -i sbt-$SBT_VERSION.deb  \
+    && rm sbt-$SBT_VERSION.deb  \
+    && apt-get update \
+    && apt-get install sbt  \
+    && sbt sbtVersion \
+# Clean up
+    && apt-get remove -qq -y wget curl \
     && rm -rf /var/lib/apt/lists/*

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,7 +1,7 @@
 FROM codesignal/ubuntu-base:v1.1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget \
+    && apt-get install -y --no-install-recommends wget java8-runtime-headless \
     && wget http://www.scala-lang.org/files/archive/scala-2.12.5.deb \
     && dpkg -i scala-2.12.5.deb \
     && apt-get update \

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -4,8 +4,9 @@ ENV SCALA_VERSION=2.12.7 \
     SBT_VERSION=1.2.6
 
 # Scala Expects this file to exist
-RUN touch /usr/lib/jvm/java-11-openjdk-amd64/release \
-    && apt-get update \
+# touch /usr/lib/jvm/java-11-openjdk-amd64/release
+RUN  \
+    apt-get update \
     && apt-get install -y --no-install-recommends wget curl \
 # Install Scala, pipe curl into tar.
     && curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ \

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,25 +1,9 @@
 FROM codesignal/java:v1.1
 
-ENV SCALA_VERSION=2.12.7 \
-    SBT_VERSION=1.2.6
-
-# Scala Expects this file to exist
-# touch /usr/lib/jvm/java-11-openjdk-amd64/release
-RUN  \
-    apt-get update \
-    && apt-get install -y --no-install-recommends wget curl \
-# Install Scala, pipe curl into tar.
-    && curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ \
-    && echo >> /root/.bashrc  \
-# Install SBT
-    # && curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb  \
-    # && dpkg -i sbt-$SBT_VERSION.deb  \
-    # && rm sbt-$SBT_VERSION.deb  \
-    # && apt-get update \
-    # && apt-get install sbt  \
-    # && sbt sbtVersion \
-# Skip Clean up, having issue with pkgProblmeResolver.
-    # && apt-get remove -qq -y wget curl \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV PATH=~/scala-$SCALA_VERSION/bin:$PATH
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && wget http://www.scala-lang.org/files/archive/scala-2.12.5.deb \
+    && dpkg -i scala-2.12.5.deb \
+    && apt-get update \
+    && apt-get install -y scala \
+    && rm -rf scala-2.12.5.deb  /var/lib/apt/lists/*

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -11,7 +11,6 @@ RUN  \
 # Install Scala, pipe curl into tar.
     && curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ \
     && echo >> /root/.bashrc  \
-    && echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc \
 # Install SBT
     # && curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb  \
     # && dpkg -i sbt-$SBT_VERSION.deb  \
@@ -22,3 +21,5 @@ RUN  \
 # Clean up
     && apt-get remove -qq -y wget curl \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=~/scala-$SCALA_VERSION/bin:$PATH

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,0 +1,12 @@
+FROM codesignal/ubuntu-base:v1.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && wget http://www.scala-lang.org/files/archive/scala-2.12.5.deb \
+    && dpkg -i scala-2.12.5.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends scala \
+# Remove deb file and clean up
+    && apt-get remove -qq -y wget \
+    && rm scala-2.15.5.deb \
+    && rm -rf /var/lib/apt/lists/*

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -18,8 +18,8 @@ RUN  \
     # && apt-get update \
     # && apt-get install sbt  \
     # && sbt sbtVersion \
-# Clean up
-    && apt-get remove -qq -y wget curl \
+# Skip Clean up, having issue with pkgProblmeResolver.
+    # && apt-get remove -qq -y wget curl \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=~/scala-$SCALA_VERSION/bin:$PATH

--- a/scala/README.md
+++ b/scala/README.md
@@ -1,0 +1,1 @@
+Scala user code execution environment.


### PR DESCRIPTION
Fixes #11 

Splits out the remaining explicit languages (Galen requests need to be done as well? I'll open a new issue for that)
#### Languages:
- [x] dart :white_check_mark:
- [x] erlang :white_check_mark:
- [x] elixir :white_check_mark:
- [x] groovy :white_check_mark:
- [x] julia :white_check_mark:
- [x] kotlin :white_check_mark:
- [x] lisp :white_check_mark:
- [x] perl :white_check_mark:
- [x] rust (Adjusted the install so there's a new run command, provided in [this](https://github.com/CodeSignal/coderunner/pull/148) PR) :white_check_mark:
- [x] scala :white_check_mark:
- [x] vb (relies on C# container, so you'll need to rebuild that one). :white_check_mark:

### Testing
Coderunner already has an additional "add" test for all of these languages, which mirrors exactly what the full app sends to the coderunner (I just copied a successful request and put it in a test). Let me know if there are any additional modes / ways of running the languages that should also be tested. 