### PR TITLE
Adds a js language container

### DIFF
--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -1,0 +1,25 @@
+FROM codesignal/ubuntu-base:v1.1
+
+# Node and npm inherited from ubuntu-base.
+RUN npm install -g \
+    async \
+    co \
+    connect \
+    crypto-js \
+    debug \
+    forever  \
+    http \
+    jquery \
+    lodash \
+    mysql \
+    mysql2 \
+    request \
+    sequelize \
+    shelljs \
+    sys \
+    underscore \
+    validator  \
+    when \
+    ws 
+
+ENV NODE_PATH=/usr/lib/node_modules/

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,1 @@
+Javascript user code execution environment.


### PR DESCRIPTION
Create a `js` language container that includes all of the npm dependencies.

Built locally as `codesignal/js:v1.1`, and ran this with add (we don't have an "add" test yet for js in the coderunner.... and we can add one later). Also included a wild `require('lodash')` just to make sure we have the dependencies.

![screen shot 2018-10-31 at 6 03 51 pm](https://user-images.githubusercontent.com/15057490/47826842-850d9600-dd37-11e8-9213-41461f8f79c6.png)
