### PR TITLE
Java-project

### DIFF
--- a/java-project/Dockerfile
+++ b/java-project/Dockerfile
@@ -1,0 +1,7 @@
+FROM codesignal/java:v1.1
+
+RUN mkdir --parents /usr/src/app
+ADD pom.xml /usr/src/app
+
+# Hopefully get downloads out of the way
+RUN mvn verify clean --fail-never

--- a/java-project/Dockerfile
+++ b/java-project/Dockerfile
@@ -1,6 +1,7 @@
 FROM codesignal/java:v1.1
 
 RUN mkdir --parents /usr/src/app
+WORKDIR /usr/src/app
 ADD pom.xml /usr/src/app
 
 # Hopefully get downloads out of the way

--- a/java-project/README.md
+++ b/java-project/README.md
@@ -1,0 +1,5 @@
+Java project container, use for running Maven and Gradle projects.
+
+Contains a cache of dependencies (like JUnit) to speed up code execution.
+
+Dependencies are listed over in the sibling `pom.xml` file.

--- a/java-project/README.md
+++ b/java-project/README.md
@@ -1,5 +1,5 @@
 Java project container, use for running Maven and Gradle projects.
 
-Contains a cache of dependencies (like JUnit) to speed up code execution.
+Contains a cache of dependencies (like JUnit) to speed up code execution. You'll find this cache in the docker container at `~/.m2` (and so will Maven!). 
 
 Dependencies are listed over in the sibling `pom.xml` file.

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -78,6 +78,7 @@
       <plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+        <version>2.1.0.RELEASE</version>
 			</plugin>
     </plugins>
   </build>

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.keyholesoftware.blog</groupId>
+  <artifactId>khs-docker-caching-blog</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <surefire.version>2.8.1</surefire.version>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <!-- lock down our surefire provider -->
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>${surefire.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -18,16 +18,19 @@
     <dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
+      <version>2.1.0.RELEASE</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+      <version>2.1.0.RELEASE</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+      <version>2.1.0.RELEASE</version>
 		</dependency>
 
 		<dependency>
@@ -39,6 +42,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+      <version>2.1.0.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -1,12 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.keyholesoftware.blog</groupId>
-  <artifactId>khs-docker-caching-blog</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <groupId>com.codesignal</groupId>
+  <artifactId>codesignal-dependency-project</artifactId>
+  <version>1.0</version>
 
   <dependencies>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-agroal</artifactId>
+      <version>5.3.7.Final</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.1.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -33,6 +75,10 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
     </plugins>
   </build>
 

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -16,7 +16,7 @@
   </dependencies>
 
   <properties>
-    <surefire.version>2.8.1</surefire.version>
+    <surefire.version>2.17</surefire.version>
   </properties>
   <build>
     <plugins>

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -62,11 +62,11 @@
     </dependency>
 
     <dependency>
-    <groupId>junit</groupId>
-    <artifactId>junit</artifactId>
-    <version>3.8.2</version>
-    <scope>test</scope>
-</dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.2</version>
+      <scope>test</scope>
+  </dependency>
   </dependencies>
 
   <properties>

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -60,6 +60,13 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>3.8.2</version>
+    <scope>test</scope>
+</dependency>
   </dependencies>
 
   <properties>

--- a/java-project/pom.xml
+++ b/java-project/pom.xml
@@ -36,6 +36,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
+      <version>1.4.197</version>
 			<scope>runtime</scope>
 		</dependency>
 


### PR DESCRIPTION
Fixes [128](https://github.com/CodeSignal/coderunner/issues/128)

Adds a new container which builds dependencies for a custom `pom.xml`. This utilizes Maven's built in caching system, and we can specify any dependency version to have it pre-installed for projects that may need it. Had to guess slightly on some of the springframework / h2 / hibernate versions we want, but luckily iteration is pretty easy.

## To Test
- Build this container as `codesignal/java-project:v1.1` in a coderunner VM, modify the coderunner so that the frameworks `junitMaven` and `junitGradle` target the `codesignal/java-project:v1.1` container.
- Try hitting both of those testing endpoints. Maven should now respond in ~ 20 seconds, Gradle should respond in ~20 seconds as well. This is down from 40+ seconds and corresponds to a per-request run time of around 6-7 seconds, which is comparable to the raw java requests which take ~ 4 seconds to run.

