### PR TITLE
Specify tensorflow version

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -19,7 +19,7 @@ RUN conda create -n py2 -y python=2 \
        pandas \
        atlas \
        scikit-learn \
-       tensorflow \
+       tensorflow=1.11.0 \
        keras \
        nltk \
        requests \
@@ -34,7 +34,7 @@ RUN conda create -n py2 -y python=2 \
        pandas \
        atlas \
        scikit-learn \
-       tensorflow \
+       tensorflow=1.11.0 \
        keras \
        nltk \
        requests \


### PR DESCRIPTION
Because version `1.12.0` is ~ 100500x times larger than `1.11.0`. Because of reasons.