### PR TITLE
Update UbuntuBase, increment all versions

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -55,3 +55,7 @@ RUN echo "deb http://cn.archive.ubuntu.com/ubuntu/ xenial main restricted univer
 # Clean up
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
+
+# Hack required for mysql to work with the "overlay2" filesystem, see link for more details:
+#   https://serverfault.com/questions/870568/fatal-error-cant-open-and-lock-privilege-tables-table-storage-engine-for-use/872576#872576
+RUN echo "chown -R mysql:mysql /var/lib/mysql /var/run/mysqld" >> ~/.bashrc

--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
   && add-apt-repository -y ppa:jonathonf/lisp \

--- a/coffeescript/Dockerfile
+++ b/coffeescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 #Install CoffeeScript
 RUN npm install -g coffeescript@next

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
   && apt-get update \

--- a/cs/Dockerfile
+++ b/cs/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \

--- a/d/Dockerfile
+++ b/d/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends wget libcurl3 \

--- a/dart/Dockerfile
+++ b/dart/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 #Install Dart 1.24.2
 RUN apt-get update \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/erlang:v1.1
+FROM codesignal/erlang:v2.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends elixir \

--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget \

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
     && add-apt-repository -y ppa:longsleep/golang-backports \

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v1.1
+FROM codesignal/java:v2.0
 
 ENV GROOVY_VERSION 2.4.15
 

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends haskell-platform \

--- a/java-project/Dockerfile
+++ b/java-project/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v1.1
+FROM codesignal/java:v2.0
 
 # Pulling things from the maven central repository into maven's cache at ~/.m2
 

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN add-apt-repository -y ppa:linuxuprising/java \
     && apt-get update \

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 # Node and npm inherited from ubuntu-base.
 RUN npm install -g \
@@ -20,6 +20,6 @@ RUN npm install -g \
     underscore \
     validator  \
     when \
-    ws 
+    ws
 
 ENV NODE_PATH=/usr/lib/node_modules/

--- a/julia-1/Dockerfile
+++ b/julia-1/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN JULIA_PATH=/usr/local/julia \
     JULIA_VERSION=1.0.1 ;\

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 #Install Julia 0.6.2, from https://github.com/docker-library/julia/blob/master/Dockerfile
 RUN JULIA_PATH=/usr/local/julia \

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v1.1
+FROM codesignal/java:v2.0
 
 RUN KOTLIN_VERSION=1.2.40 \
     KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip ; \

--- a/lisp/Dockerfile
+++ b/lisp/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 #Install Lua
 RUN apt-get update \

--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
     && add-apt-repository -y ppa:jonathonf/nimlang \

--- a/ocaml/Dockerfile
+++ b/ocaml/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ocaml ocaml-batteries-included \

--- a/octave/Dockerfile
+++ b/octave/Dockerfile
@@ -1,5 +1,5 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends octave \ 
+    && apt-get install -y --no-install-recommends octave \
     && rm -rf /var/lib/apt/lists/*

--- a/pascal/Dockerfile
+++ b/pascal/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
     && apt-get install -y fpc \

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN add-apt-repository ppa:ondrej/php \
   && apt-get -qq -y update \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get -qq update \
     && apt-get -qq -y install curl bzip2 --no-install-recommends \

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN add-apt-repository -y ppa:marutter/rrutter \
   && add-apt-repository -y ppa:marutter/c2d4u \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-add-repository ppa:brightbox/ruby-ng \
     && apt-get -qq update \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v1.1
+FROM codesignal/java:v2.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget \

--- a/smalltalk/Dockerfile
+++ b/smalltalk/Dockerfile
@@ -1,5 +1,5 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gnu-smalltalk \ 
+    && apt-get install -y --no-install-recommends gnu-smalltalk \
     && rm -rf /var/lib/apt/lists/*

--- a/swift-4/Dockerfile
+++ b/swift-4/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 ENV SWIFT_BRANCH=swift-4.2.1-release \
     SWIFT_VERSION=swift-4.2.1-RELEASE \

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 ENV SWIFT_BRANCH=swift-3.1.1-release \
     SWIFT_VERSION=swift-3.1.1-RELEASE \

--- a/tcl/Dockerfile
+++ b/tcl/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends tcl8.6 tcllib \

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v1.1
+FROM codesignal/ubuntu-base:v2.0
 
 #Install TypeScript
 # For @types/node@9.6.7 see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342


### PR DESCRIPTION
Incrementing all versions after an update to ubuntu-base.

Update to `ubuntu-base` comprises adding a command to the startup `~/.bashrc` for root, which is necessary to get mysql to start up correctly. It's weird and hacky and the `chown` modifications are already made above, but something about the `overlay2` filesystem is not letting mysql startup. We could have switched to the `aufs` filesystem for docker which would also fix the issue, but that has potential performance implications.