### PR TITLE
Add Mongodb to base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -68,8 +68,6 @@ RUN apt-get update \
 # Setup mongodb server
 RUN mkdir -p /data/mongodb /data/configdb \
     && chown -R mongodb:mongodb /data/mongodb /data/configdb
-# Declares these here, prevents extensions from adding files
-VOLUME /data/mongodb /data/configdb
+
 ADD mongod.conf /etc/mongod.conf
 ADD mongodb.conf /etc/mongodb.conf
-ADD ./mongod_runner.sh /usr/src/mongod_runner.sh

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -56,6 +56,20 @@ RUN echo "deb http://cn.archive.ubuntu.com/ubuntu/ xenial main restricted univer
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-# Hack required for mysql to work with the "overlay2" filesystem, see link for more details:
-#   https://serverfault.com/questions/870568/fatal-error-cant-open-and-lock-privilege-tables-table-storage-engine-for-use/872576#872576
-RUN echo "chown -R mysql:mysql /var/lib/mysql /var/run/mysqld" >> ~/.bashrc
+#Install mongodb server
+RUN apt-get update \
+    && apt-get install -y mongodb-server \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 \
+    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.0.list \
+    && apt-get update \
+    && apt-get install -y mongodb-org=4.0.5 mongodb-org-server=4.0.5 mongodb-org-shell=4.0.5 mongodb-org-mongos=4.0.5 mongodb-org-tools=4.0.5 \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/mongodb
+# Setup mongodb server
+RUN mkdir -p /data/mongodb /data/configdb \
+    && chown -R mongodb:mongodb /data/mongodb /data/configdb
+# Declares these here, prevents extensions from adding files
+VOLUME /data/mongodb /data/configdb
+ADD mongod.conf /etc/mongod.conf
+ADD mongodb.conf /etc/mongodb.conf
+ADD ./mongod_runner.sh /usr/src/mongod_runner.sh

--- a/base/mongod.conf
+++ b/base/mongod.conf
@@ -1,0 +1,43 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# Where and how to store data.
+storage:
+  dbPath: /data/mongodb
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# network interfaces
+net:
+  port: 27017
+  bindIp: 127.0.0.1
+
+
+# how the process runs
+processManagement:
+  timeZoneInfo: /usr/share/zoneinfo
+
+#security:
+
+#operationProfiling:
+
+#replication:
+
+#sharding:
+
+## Enterprise-Only Options:
+
+#auditLog:
+
+#snmp:

--- a/base/mongod_runner.sh
+++ b/base/mongod_runner.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+service mongodb start 2>&1 > /dev/null
+echo "----BEGIN----"
+
+echo "----END----"

--- a/base/mongod_runner.sh
+++ b/base/mongod_runner.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-service mongodb start 2>&1 > /dev/null
-echo "----BEGIN----"
-
-echo "----END----"

--- a/base/mongodb.conf
+++ b/base/mongodb.conf
@@ -1,0 +1,100 @@
+# mongodb.conf
+
+# Where to store the data.
+dbpath=/data/mongodb
+
+#where to log
+logpath=/var/log/mongodb/mongodb.log
+
+logappend=true
+
+bind_ip = 127.0.0.1
+#port = 27017
+
+# Enable journaling, http://www.mongodb.org/display/DOCS/Journaling
+journal=true
+
+# Enables periodic logging of CPU utilization and I/O wait
+#cpu = true
+
+# Turn on/off security.  Off is currently the default
+#noauth = true
+#auth = true
+
+# Verbose logging output.
+#verbose = true
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+#objcheck = true
+
+# Enable db quota management
+#quota = true
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+#oplog = 0
+
+# Diagnostic/debugging option
+#nocursors = true
+
+# Ignore query hints
+#nohints = true
+
+# Disable the HTTP interface (Defaults to localhost:27018).
+#nohttpinterface = true
+
+# Turns off server-side scripting.  This will result in greatly limited
+# functionality
+#noscripting = true
+
+# Turns off table scans.  Any query that would do a table scan fails.
+#notablescan = true
+
+# Disable data file preallocation.
+#noprealloc = true
+
+# Specify .ns file size for new databases.
+# nssize = <size>
+
+# Accout token for Mongo monitoring server.
+#mms-token = <token>
+
+# Server name for Mongo monitoring server.
+#mms-name = <server-name>
+
+# Ping interval for Mongo monitoring server.
+#mms-interval = <seconds>
+
+# Replication Options
+
+# in replicated mongo databases, specify here whether this is a slave or master
+#slave = true
+#source = master.example.com
+# Slave only: specify a single database to replicate
+#only = master.example.com
+# or
+#master = true
+#source = slave.example.com
+
+# Address of a server to pair with.
+#pairwith = <server:port>
+# Address of arbiter server.
+#arbiter = <server:port>
+# Automatically resync if slave data is stale
+#autoresync
+# Custom size for replication operation log.
+#oplogSize = <MB>
+# Size limit for in-memory storage of op ids.
+#opIdMem = <bytes>
+
+# SSL options
+# Enable SSL on normal ports
+#sslOnNormalPorts = true
+# SSL Key file and password
+#sslPEMKeyFile = /etc/ssl/mongodb.pem
+#sslPEMKeyPassword = pass

--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
   && add-apt-repository -y ppa:jonathonf/lisp \

--- a/coffeescript/Dockerfile
+++ b/coffeescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 #Install CoffeeScript
 RUN npm install -g coffeescript@next

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
   && apt-get update \

--- a/cs/Dockerfile
+++ b/cs/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \

--- a/d/Dockerfile
+++ b/d/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends wget libcurl3 \

--- a/dart/Dockerfile
+++ b/dart/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 #Install Dart 1.24.2
 RUN apt-get update \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/erlang:v2.0
+FROM codesignal/erlang:v3.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends elixir \

--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget \

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && add-apt-repository -y ppa:longsleep/golang-backports \

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v2.0
+FROM codesignal/java:v3.0
 
 ENV GROOVY_VERSION 2.4.15
 

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends haskell-platform \

--- a/java-project/Dockerfile
+++ b/java-project/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v2.0
+FROM codesignal/java:v3.0
 
 # Pulling things from the maven central repository into maven's cache at ~/.m2
 

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN add-apt-repository -y ppa:linuxuprising/java \
     && apt-get update \

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 # Node and npm inherited from ubuntu-base.
 RUN npm install -g \

--- a/julia-1/Dockerfile
+++ b/julia-1/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN JULIA_PATH=/usr/local/julia \
     JULIA_VERSION=1.0.1 ;\

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 #Install Julia 0.6.2, from https://github.com/docker-library/julia/blob/master/Dockerfile
 RUN JULIA_PATH=/usr/local/julia \

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v2.0
+FROM codesignal/java:v3.0
 
 RUN KOTLIN_VERSION=1.2.40 \
     KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip ; \

--- a/lisp/Dockerfile
+++ b/lisp/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 #Install Lua
 RUN apt-get update \

--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && add-apt-repository -y ppa:jonathonf/nimlang \

--- a/ocaml/Dockerfile
+++ b/ocaml/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ocaml ocaml-batteries-included \

--- a/octave/Dockerfile
+++ b/octave/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends octave \

--- a/pascal/Dockerfile
+++ b/pascal/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && apt-get install -y fpc \

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN add-apt-repository ppa:ondrej/php \
   && apt-get -qq -y update \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get -qq update \
     && apt-get -qq -y install curl bzip2 --no-install-recommends \

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN add-apt-repository -y ppa:marutter/rrutter \
   && add-apt-repository -y ppa:marutter/c2d4u \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-add-repository ppa:brightbox/ruby-ng \
     && apt-get -qq update \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v2.0
+FROM codesignal/java:v3.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget \

--- a/smalltalk/Dockerfile
+++ b/smalltalk/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gnu-smalltalk \

--- a/swift-4/Dockerfile
+++ b/swift-4/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 ENV SWIFT_BRANCH=swift-4.2.1-release \
     SWIFT_VERSION=swift-4.2.1-RELEASE \

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 ENV SWIFT_BRANCH=swift-3.1.1-release \
     SWIFT_VERSION=swift-3.1.1-RELEASE \

--- a/tcl/Dockerfile
+++ b/tcl/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends tcl8.6 tcllib \

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v2.0
+FROM codesignal/ubuntu-base:v3.0
 
 #Install TypeScript
 # For @types/node@9.6.7 see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342


### PR DESCRIPTION
Fixes #42 

Adds mongodb to base image. You can test this out locally by building the container and running `service mongodb start` in the container. You should enter a running database image that you can modify. Also removed unnecessary hack about file permissions.

Any additional mongodb configuration should be able to be done in a script like `mongodb_runner.sh` for account setup / data population.

The configuration files are provided to target a specific folder for the database, `/data/mongodb`. I just copied the default files and changed the `dbPath` lines.

## To Test:
1. Checkout this branch, cd to `base` folder, run `docker build -t codesignal/ubuntu-base:v3.0 . && docker run -it codesignal/ubuntu-base:v3.0 /bin/bash`. This should build the container and let you enter it.
2. Running `service mongodb start` should return `[OK]`
3. Running `mongo` should take you to the mongo shell where you can now add databases if you want to.