### PR TITLE
JS: install chai globally

### DIFF
--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -3,6 +3,7 @@ FROM codesignal/ubuntu-base:v4.0
 # Node and npm inherited from ubuntu-base.
 RUN npm install -g \
     async \
+    chai \
     co \
     connect \
     crypto-js \


### PR DESCRIPTION
Makes sure we can actually run tests by installing chai globally as well.