### PR TITLE
Updated Java, Maven & Gradle

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -2,10 +2,10 @@ FROM codesignal/ubuntu-base:v4.0
 
 RUN add-apt-repository -y ppa:linuxuprising/java \
     && apt-get update \
-    && echo oracle-java11-installer shared/accepted-oracle-license-v1-2 select true | /usr/bin/debconf-set-selections \
+    && echo oracle-java12-installer shared/accepted-oracle-license-v1-2 select true | /usr/bin/debconf-set-selections \
     && apt-get install -y --no-install-recommends \
-        oracle-java11-installer \
-        oracle-java11-set-default \
+        oracle-java12-installer \
+        oracle-java12-set-default \
         libjackson2-core-java \
         libjackson2-databind-java \
         libmysql-java \
@@ -15,13 +15,24 @@ RUN add-apt-repository -y ppa:linuxuprising/java \
 # install gradle
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \
-    && wget https://services.gradle.org/distributions/gradle-4.10.2-bin.zip -P /opt/ \
-    && unzip /opt/gradle-4.10.2-bin.zip -d /opt/gradle \
+    && wget https://services.gradle.org/distributions/gradle-5.4.1-bin.zip -P /opt/ \
+    && unzip /opt/gradle-5.4.1-bin.zip -d /opt/gradle \
     && apt-get remove -qq -y unzip \
     && apt-get autoremove -qq -y \
     && apt-get autoclean \
-    && rm /opt/gradle-4.10.2-bin.zip \
+    && rm /opt/gradle-5.4.1-bin.zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# install maven
+RUN wget https://www-us.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz -P /opt/ \
+    && mkdir /opt/maven \
+    && tar -xzf /opt/apache-maven-3.6.1-bin.tar.gz -C /opt/maven --strip-components 1 \
+    && apt-get autoremove -qq -y \
+    && apt-get autoclean \
+    && rm /opt/apache-maven-3.6.1-bin.tar.gz \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CLASSPATH=/usr/share/java/*:$CLASSPATH \
-    PATH=/opt/gradle/gradle-4.10.2/bin:$PATH
+    M2_HOME=/opt/maven \
+    MAVEN_HOME=/opt/maven \
+    PATH=$M2_HOME/bin:/opt/gradle/gradle-5.4.1/bin:$PATH


### PR DESCRIPTION
First part of https://github.com/CodeSignal/coderunner/issues/261. Please refer to the "upgrade plan" section below. I will repeat this header in other related PRs, too.

__Upgrade plan__

1) Upgrade main `java` image. __This is what this PR is about!__ It updates Java to `12`, Gradle to `5.4.1`, and Maven to `3.6.1`.
2) Upgrade all images that depend on the main `java` image. There are no major functional changes; we just want to use the updated Java image as a base, that's all. This will have to wait until main `java` image is published on dockerhub.
3) Update coderunners to use the latest versions of docker images. This will have to wait until all java-dependant images are published on dockerhub.

__How to test this__

So, with three blocking steps, is there a way to test it all at once? Yes! I went ahead and built all images locally on the coderunner with IP `162.243.19.48`. You can find it on Rundash. Feel free to SSH into it, run tests on it, or send requests to it. I don't mind. 

All tests are passing, so there's that. You can also do something like this to double check the versions:
![image](https://user-images.githubusercontent.com/8866457/60138750-5b8afa00-9760-11e9-9a7d-524e9ca157bd.png)

For your convenience, here's the script I'm running in the screenshot above:
```sh
java --version
echo '---------------------------------------------------------------------------------------------'
gradle --version
echo '---------------------------------------------------------------------------------------------'
mvn --version
```