### PR TITLE
Add r-cran-tryCatchLog

### DIFF
--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -11,4 +11,5 @@ RUN add-apt-repository -y ppa:marutter/rrutter \
     r-cran-dplyr \
     r-cran-magrittr \
     r-cran-data.table \
+    r-cran-tryCatchLog \
   && rm -rf /var/lib/apt/lists/*

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -11,5 +11,5 @@ RUN add-apt-repository -y ppa:marutter/rrutter \
     r-cran-dplyr \
     r-cran-magrittr \
     r-cran-data.table \
-    r-cran-tryCatchLog \
+    r-cran-trycatchlog \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
[no issue]

I really want to add this for the sake of being able to print proper runtime error stack traces in R.

https://cran.r-project.org/web/packages/tryCatchLog/index.html

Confession: I didn't test that this works.