### PR TITLE
Add tryCatchLog package for Rlang

### DIFF
--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -11,4 +11,5 @@ RUN add-apt-repository -y ppa:marutter/rrutter \
     r-cran-dplyr \
     r-cran-magrittr \
     r-cran-data.table \
+    r-cran-tryCatchLog \
   && rm -rf /var/lib/apt/lists/*

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -11,5 +11,5 @@ RUN add-apt-repository -y ppa:marutter/rrutter \
     r-cran-dplyr \
     r-cran-magrittr \
     r-cran-data.table \
-    r-cran-tryCatchLog \
+    r-cran-trycatchlog \
   && rm -rf /var/lib/apt/lists/*

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -11,5 +11,7 @@ RUN add-apt-repository -y ppa:marutter/rrutter \
     r-cran-dplyr \
     r-cran-magrittr \
     r-cran-data.table \
-    r-cran-trycatchlog \
   && rm -rf /var/lib/apt/lists/*
+
+RUN echo "r <- getOption('repos'); r['CRAN'] <- 'https://cloud.r-project.org/'; options(repos = r);" > ~/.Rprofile
+RUN Rscript -e "install.packages('tryCatchLog')"


### PR DESCRIPTION
Closes #76. For real this time.

There is now a successful build on DockerHub that shows this works:
https://cloud.docker.com/u/codesignal/repository/registry-1.docker.io/codesignal/r-env/builds/17d9b82c-80b5-4d2f-ad51-dfe673a5faba

The problem with my previous hastily-submitted PR is that while the `r-cran-*` format works for _some_ R packages, it doesn't work for all, including `tryCatchLog`. However, we can simply execute some R code to use R's own package management instead of trying to use APT.

This is a 2-line PR in which...
- The first line sets an R package mirror (i.e., a place where we can download packages from)
- The second line installs `tryCatchLog` so that it will be available in R images

For now, I think testing that the Docker build succeeds is adequate for this PR! However, I also ran this installation code as a free-coding task in CodeSignal's main app to prove that the technique will work in general:
![Screen Shot 2019-08-22 at 1 45 22 PM](https://user-images.githubusercontent.com/747378/63549895-41626380-c4e6-11e9-9e1c-4431a4911773.png)
