### PR TITLE
Create a .NET Core Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 A collection of Dockerfiles for CodeSignal user code execution. Look at the `README` associated with each individual file to find information no a specific image.
 
-## Instructions for releasing new versions
+## Creating or editing a Dockerfile
+
+Run your Dockerfile through this linting tool to look for possible bugs or optimizations:
+https://www.fromlatest.io/#/
+
+## Releasing new versions
 
 ### Updating the image itself:
 

--- a/cs/README.md
+++ b/cs/README.md
@@ -1,3 +1,3 @@
-User code execution environment for C#, F#, and Visual Basic.
+User code execution environment for C#, F#, and Visual Basic, using .NET Framework/Mono.
 
 Visual Basic support provided by the `mono-vbnc` package.

--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -7,13 +7,14 @@ FROM codesignal/ubuntu-base:v5.0
 RUN wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 
-# need this to skip Y/n questions during SDK install
+# skip Y/n questions during SDK install
 ENV DEBIAN_FRONTEND='noninteractive'
 
 # Install .NET SDK
-RUN apt-get install apt-transport-https
-RUN apt-get update
-RUN apt-get -yq install dotnet-sdk-2.2
+RUN apt-get -yq install apt-transport-https --no-install-recommends \
+  && apt-get update \
+  && apt-get -yq install dotnet-sdk-2.2 --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 
 # Verify
 RUN dotnet --version

--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -7,10 +7,13 @@ FROM codesignal/ubuntu-base:v5.0
 RUN wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 
+# need this to skip Y/n questions during SDK install
+ENV DEBIAN_FRONTEND='noninteractive'
+
 # Install .NET SDK
 RUN apt-get install apt-transport-https
 RUN apt-get update
-RUN apt-get install dotnet-sdk-2.2
+RUN apt-get -yq install dotnet-sdk-2.2
 
 # Verify
 RUN dotnet --version

--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -1,0 +1,16 @@
+FROM codesignal/ubuntu-base:v5.0
+
+# Based on instructions here:
+# https://dotnet.microsoft.com/download/linux-package-manager/ubuntu16-04/sdk-current
+
+# register Microsoft key and feed
+RUN wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+
+# Install .NET SDK
+RUN apt-get install apt-transport-https
+RUN apt-get update
+RUN apt-get install dotnet-sdk-2.2
+
+# Verify
+RUN dotnet --version

--- a/dotnetcore/README.md
+++ b/dotnetcore/README.md
@@ -1,0 +1,1 @@
+User code execution environment for .NET Core.


### PR DESCRIPTION
Closes #81.

Successful Dockerhub build:
https://cloud.docker.com/u/codesignal/repository/registry-1.docker.io/codesignal/dotnetcore/builds/ac6e8b6c-03b1-4747-b738-dd6c3d396c84

(The last command is `dotnet --version`, which successfully returns `2.2.401`.)

I verified that this is enough to run a simple .NET Core "hello world" example, as well as a slightly more complicated example using packages like xUnit and Json.NET. (If you'd like to test yourself, I can point you to some more specific setup, just don't want to post it here in the PR body since this is a public repo and some of that stuff is a bit internal in nature.)