### PR TITLE
Update PostgreSQL installation in dockerfile of base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
             declare -A REPOMAP
             REPOMAP[r]='r-env'
             REPOMAP[d]='d-env'
+            REPOMAP[base]='ubuntu-base'
 
             echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -38,9 +38,6 @@ RUN echo "deb http://cn.archive.ubuntu.com/ubuntu/ xenial main restricted univer
        libpq5 \
        libssl-dev \
        mysql-server-5.7 \
-       postgresql \
-       postgresql-client \
-       postgresql-contrib \
     && mkdir -p /var/lib/mysql \
     && mkdir -p /var/run/mysqld \
     && mkdir -p /var/log/mysql \
@@ -77,4 +74,16 @@ ADD mongodb.conf /etc/mongodb.conf
 RUN add-apt-repository ppa:git-core/ppa -y \
     && apt-get update \
     && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Installing PostgreSQL with extensions
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" >> /etc/apt/sources.list.d/pgdg.list \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       postgresql-12 \
+       postgresql-client-12 \
+       postgresql-contrib-12 \
+       postgis \
+       postgresql-12-postgis-2.5 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
closes:
#122 Update PostgreSQL version from 9.5 to the latest stable (11 or 12)
#130 Add PostgreSQL libraries/extensions

### Changes
In this PR I modified the `codesignal/ubuntu-base` dockerfile to upgrade PostgreSQL to the version 12 and include the libraries `postgis` and `postgis_topology`.

I have also pushed the locally built image to dockerhub with tag `dev `https://hub.docker.com/repository/docker/codesignal/ubuntu-base to connect it with a custom coderunner (https://github.com/CodeSignal/coderunner/pull/507) and test it.

### Testing

Go to http://159.89.233.12:12345/ - the coderunner pointing to the new image, and run the following queries.

#### To make sure the version was updated from 9.5
The keyword `INCLUDE` is newly introduced, used while creating index.
```sql
CREATE TABLE employees(empid INT, empname VARCHAR(10));
CREATE INDEX empid_idx ON employees(empid) INCLUDE (empname);
```
You should see an empty output instead  of red `SYNTAX_ERROR`.

#### To make sure the `postgis` extension is working
```sql
CREATE EXTENSION postgis;

CREATE TABLE geometries (name varchar, geom geometry);

INSERT INTO geometries VALUES
  ('Point', 'POINT(0 0)'),
  ('PolygonWithHole', 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),(1 1, 1 2, 2 2, 2 1, 1 1))'),
  ('Collection', 'GEOMETRYCOLLECTION(POINT(2 0),POLYGON((0 0, 1 0, 1 1, 0 1, 0 0)))');

SELECT name, ST_AsText(geom) FROM geometries;
```
You shouldn't see any `SYNTAX_ERROR`.


#### To make sure the `postgis_topology` extension is working too
```sql
CREATE EXTENSION postgis;
CREATE EXTENSION postgis_topology;
SELECT topologicalElement[1] AS id, topologicalElement[2] AS type FROM
( SELECT ARRAY[1,2]::topology.topoelement AS topologicalElement ) f;
```
You shouldn't see any `SYNTAX_ERROR`.


### Next steps

According to the dockerfiles README - one should create a github release in order to make sure the image is automatically being build on docker-hub without errors. When I look at the releases page I don't see any experimental releases (just for development), so I assume we create a release after the PR approval?
