### PR TITLE
Update dockerfiles of images based on ubuntu-base

### DIFF
--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.

--- a/coffeescript/Dockerfile
+++ b/coffeescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 #Install CoffeeScript
 RUN npm install -g coffeescript@next

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
   && apt-get update \

--- a/cs/Dockerfile
+++ b/cs/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \

--- a/d/Dockerfile
+++ b/d/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends libcurl3 \

--- a/dart/Dockerfile
+++ b/dart/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 #Install Dart 1.24.2
 RUN apt-get update \

--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 # Based on SDK instructions here:
 # https://dotnet.microsoft.com/download/linux-package-manager/ubuntu16-04/sdk-current

--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && add-apt-repository -y ppa:longsleep/golang-backports \

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 # install GHC and Cabal
 RUN add-apt-repository -y ppa:hvr/ghc \

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN add-apt-repository -y ppa:linuxuprising/java \
     && apt-get update \

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -2,10 +2,10 @@ FROM codesignal/ubuntu-base:v5.6
 
 RUN add-apt-repository -y ppa:linuxuprising/java \
     && apt-get update \
-    && echo oracle-java13-installer shared/accepted-oracle-license-v1-2 select true | /usr/bin/debconf-set-selections \
+    && echo oracle-java14-installer shared/accepted-oracle-license-v1-2 select true | /usr/bin/debconf-set-selections \
     && apt-get install -y --no-install-recommends \
-        oracle-java13-installer \
-        oracle-java13-set-default \
+        oracle-java14-installer \
+        oracle-java14-set-default \
         libjackson2-core-java \
         libjackson2-databind-java \
         libmysql-java \

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 # Node and npm inherited from ubuntu-base.
 RUN npm install -g \

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN JULIA_PATH=/usr/local/julia \
     JULIA_VERSION=1.0.1 ;\

--- a/lisp/Dockerfile
+++ b/lisp/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 #Install Lua
 RUN apt-get update \

--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && add-apt-repository -y ppa:jonathonf/nimlang \

--- a/objective-c/Dockerfile
+++ b/objective-c/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 ENV SWIFT_BRANCH=swift-3.1.1-release \
     SWIFT_VERSION=swift-3.1.1-RELEASE \

--- a/ocaml/Dockerfile
+++ b/ocaml/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ocaml ocaml-batteries-included \

--- a/octave/Dockerfile
+++ b/octave/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends octave \

--- a/pascal/Dockerfile
+++ b/pascal/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && apt-get install -y fpc \

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 # Install PHP & dependencies
 RUN add-apt-repository ppa:ondrej/php \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get -qq update \
     && apt-get -qq -y install bzip2 --no-install-recommends \

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN add-apt-repository -y ppa:marutter/rrutter \
   && add-apt-repository -y ppa:marutter/c2d4u \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-add-repository ppa:brightbox/ruby-ng \
     && apt-get -qq update \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && mkdir -p /opt/rust \

--- a/smalltalk/Dockerfile
+++ b/smalltalk/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gnu-smalltalk \

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 ENV SWIFT_BRANCH=swift-5.1.4-release \
     SWIFT_VERSION=swift-5.1.4-RELEASE \

--- a/tcl/Dockerfile
+++ b/tcl/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends tcl8.6 tcllib \

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/ubuntu-base:v5.5
+FROM codesignal/ubuntu-base:v5.6
 
 #Install TypeScript
 RUN npm install -g typescript @types/node


### PR DESCRIPTION
closes #136 136
sequel of https://github.com/CodeSignal/dockerfiles/pull/131

### Changes

In this PR I updated the following images to require [`codesignal/ubuntu-base:v5.6`](https://hub.docker.com/repository/docker/codesignal/ubuntu-base/builds). 

1. [acceptance-tests](https://hub.docker.com/repository/docker/codesignal/acceptance-tests/builds)
1. [coffeescript](https://hub.docker.com/repository/docker/codesignal/coffeescript/builds)
1. [cpp](https://hub.docker.com/repository/docker/codesignal/cpp/builds)
1. [cs](https://hub.docker.com/repository/docker/codesignal/cs/builds)
1. [d](https://hub.docker.com/repository/docker/codesignal/d-env/builds)
1. [dart](https://hub.docker.com/repository/docker/codesignal/dart/builds)
1. [dotnetcore](https://hub.docker.com/repository/docker/codesignal/dotnetcore/builds)
1. [erlang](https://hub.docker.com/repository/docker/codesignal/erlang/builds)
1. [go](https://hub.docker.com/repository/docker/codesignal/go/builds)
1. [haskell](https://hub.docker.com/repository/docker/codesignal/haskell/builds)
1. [java](https://hub.docker.com/repository/docker/codesignal/java/builds)
1. [js](https://hub.docker.com/repository/docker/codesignal/js/builds)
1. [julia](https://hub.docker.com/repository/docker/codesignal/julia/builds)
1. [lisp](https://hub.docker.com/repository/docker/codesignal/lisp/builds)
1. [lua](https://hub.docker.com/repository/docker/codesignal/lua/builds)
1. [nim](https://hub.docker.com/repository/docker/codesignal/nim/builds)
1. [objective-c](https://hub.docker.com/repository/docker/codesignal/objective-c/builds)
1. [ocaml](https://hub.docker.com/repository/docker/codesignal/ocaml/builds)
1. [octave](https://hub.docker.com/repository/docker/codesignal/octave/builds)
1. [pascal](https://hub.docker.com/repository/docker/codesignal/pascal/builds)
1. [perl](https://hub.docker.com/repository/docker/codesignal/perl/builds)
1. [php](https://hub.docker.com/repository/docker/codesignal/php/builds)
1. [python](https://hub.docker.com/repository/docker/codesignal/python/builds)
1. [r](https://hub.docker.com/repository/docker/codesignal/r-env/builds)
1. [ruby](https://hub.docker.com/repository/docker/codesignal/ruby/builds)
1. [rust](https://hub.docker.com/repository/docker/codesignal/rust/builds)
1. [smalltalk](https://hub.docker.com/repository/docker/codesignal/smalltalk/builds)
1. [swift](https://hub.docker.com/repository/docker/codesignal/swift/builds)
1. [tcl](https://hub.docker.com/repository/docker/codesignal/tcl/builds)
1. [typescript](https://hub.docker.com/repository/docker/codesignal/typescript/builds)

CI script made them available on dockerhub with a `dev` tag 👍.

Also, there was a need to change `oracle-java13` to `oracle-java14` - see the last log lines of the failed workflow https://circleci.com/gh/CodeSignal/dockerfiles/66.

I deployed a coderunner pointing to these `dev` images in https://github.com/CodeSignal/coderunner/pull/507 - except the `objective-c`. You can see it on rundash (IP: 142.93.193.14), tests pass.

---

### Issue with objective-c
In case of `objective-c` the [build](https://hub.docker.com/repository/registry-1.docker.io/codesignal/objective-c/builds/dce3f26c-2084-4c5f-a07d-58fa0f888e43)(triggered manually) is not failing but for some reason the resulting image isn't functioning (tests don't pass). I found this similar comment https://github.com/CodeSignal/coderunner/pull/467#issuecomment-603463124. 

I though that the issue may be related to updating the base image to v5.6. But if we compare the 3 builds below with equal dockerfiles - 1st only differ from others by the base ubuntu image version
1. [FROM codesignal/ubuntu-base:v5.6
 ](https://hub.docker.com/repository/registry-1.docker.io/codesignal/objective-c/builds/dce3f26c-2084-4c5f-a07d-58fa0f888e43) fresh build

2. [FROM codesignal/ubuntu-base:v5.5
 ](https://hub.docker.com/repository/registry-1.docker.io/codesignal/objective-c/builds/85673919-51e7-42b2-87e4-118efe8f1354) fresh build

3. [FROM codesignal/ubuntu-base:v5.5
 ](https://hub.docker.com/repository/registry-1.docker.io/codesignal/objective-c/builds/253ab7db-3610-42e2-80ab-7db94aefb328) old build

in the both fresh builds' logs there are new unclear errors which aren't present in the old build. Try a `Cmd+F` search for string "error" in the three builds' logs you'll see the difference 🙂. So I assume there is a general issue in `objective-c` dockerfile which doesn't let as updating it for now, and we might consider opening an issue for that.

Please let me know if I didn't explain anything clear enough 😺 .

---

### Next steps

When this PR is approved, I will create a release ` based-on/ubuntu-base/v5.6` to trigger dockerhub builds with version v5.6.

The next step should be updating the second level of dependencies i.e. `java` and `erlang` dependent images.
