### PR TITLE
Update dockerfiles based on cpp, erlang, java

### DIFF
--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v5.5
+FROM codesignal/java:v5.6
 
 RUN CLOJURE_VERSION=1.10.1.469 ;\
   apt-get update \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/erlang:v5.5
+FROM codesignal/erlang:v5.6
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends elixir \

--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v5.5
+FROM codesignal/java:v5.6
 
 ENV GROOVY_VERSION 2.4.15
 

--- a/java-project/Dockerfile
+++ b/java-project/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v5.6
+FROM codesignal/java:v5.5
 
 # Pulling things from the maven central repository into maven's cache at ~/.m2
 

--- a/java-project/Dockerfile
+++ b/java-project/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v5.5
+FROM codesignal/java:v5.6
 
 # Pulling things from the maven central repository into maven's cache at ~/.m2
 

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v5.5
+FROM codesignal/java:v5.6
 
 RUN KOTLIN_VERSION=1.3.61 \
     KOTLIN_COMPILER_URL=https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip ; \

--- a/opencv/Dockerfile
+++ b/opencv/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/cpp:v5.5
+FROM codesignal/cpp:v5.6
 
 ENV OPENCV_VERSION=4.2.0
 

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v5.5
+FROM codesignal/java:v5.6
 
 RUN apt-get update \
     && wget https://www.scala-lang.org/files/archive/scala-2.12.10.deb \


### PR DESCRIPTION
Closes #137

The final PR :checkered_flag: in scope of issue https://github.com/CodeSignal/dockerfiles/issues/122 

### Changes

In this PR I updated the following images to require `v5.6` version of their parent image.

1. [clojure](https://hub.docker.com/repository/docker/codesignal/clojure/builds)
1. [elixir](https://hub.docker.com/repository/docker/codesignal/elixir/builds)
1. [groovy](https://hub.docker.com/repository/docker/codesignal/groovy/builds)
1. [~java-project~](https://hub.docker.com/repository/docker/codesignal/java-project/builds) (_undone this change as per https://github.com/CodeSignal/dockerfiles/issues/142_)
1. [kotlin](https://hub.docker.com/repository/docker/codesignal/kotlin/builds)
1. [opencv](https://hub.docker.com/repository/docker/codesignal/opencv/builds)
1. [scala](https://hub.docker.com/repository/docker/codesignal/scala/builds)

CI script made them available on dockerhub with a `dev` tag 👍.

Redeployed the https://github.com/CodeSignal/coderunner/pull/519 to point to these `dev` images https://rundash.codesignal.com/coderunner-test/204.48.23.255  

test ✅

---

#### There was a need of a small fix in the java dockerfile

Issue: https://github.com/CodeSignal/dockerfiles/issues/139, which caused a bug in `java-project` image build
PR: https://github.com/CodeSignal/dockerfiles/pull/140
Release: https://github.com/CodeSignal/dockerfiles/releases/tag/java%2Fv5.6

---

### Next steps

When this PR is approved, I will create 3 releases

- ` based-on/cpp/v5.6` 
- ` based-on/java/v5.6` 
- ` based-on/erlang/v5.6` 

to trigger dockerhub builds.


