### PR TITLE
Make sure that kotlin-scripting-compiler-embeddable is loaded during …

### DIFF
--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM codesignal/java:v8.1.2
+FROM codesignal/java:java-gradle
 
 # Upload build.gradle script
 COPY build.gradle /usr/share/java

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -3,6 +3,8 @@ FROM codesignal/java:v8.1.2
 # Upload build.gradle script
 COPY build.gradle /usr/share/java
 
+ENV KOTLIN_VERSION='1.4.31'
+
 # The command below downloads the dependencies and stores them in the machine memory.
 # It should NOT be removed because it will be used to run kotlin code in the coderunner.
 RUN cd /usr/share/java \

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,9 +1,9 @@
 FROM codesignal/java:v8.1.2
 
 # Upload build.gradle script
-COPY build.gradle /usr/share/java/build.gradle
+COPY build.gradle /usr/share/java
 
 # The command below downloads the dependencies and stores them in the machine memory.
 # It should NOT be removed because it will be used to run kotlin code in the coderunner.
 RUN cd /usr/share/java \
-    && gradle build
+    && gradle build --build-cache

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -3,8 +3,6 @@ FROM codesignal/java:v8.1.2
 # Upload build.gradle script
 COPY build.gradle /usr/share/java
 
-ENV KOTLIN_VERSION='1.4.31'
-
 # The command below downloads the dependencies and stores them in the machine memory.
 # It should NOT be removed because it will be used to run kotlin code in the coderunner.
 RUN cd /usr/share/java \

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -27,3 +27,7 @@ sourceSets {
 application {
     mainClassName = 'MainKt'
 }
+
+compileKotlin {
+    kotlinOptions.allWarningsAsErrors = false
+}

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable"
     implementation "org.jetbrains.kotlin:kotlin-serialization"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0"
 }
 

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.4.10'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.0-M1'
     id 'application'
 }
 
@@ -8,10 +8,12 @@ repositories {
 }
 
 dependencies {
-    implementation fileTree(dir: "/usr/share/java", include: "*.jar")
-    implementation platform("org.jetbrains.kotlin:kotlin-bom")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:$System.env.JACKSON_VERSION"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$System.env.JACKSON_VERSION"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$System.env.JACKSON_VERSION"
+    implementation "mysql:mysql-connector-java:$System.env.MYSQL_CONNECTOR_JAVA_VERSION"
+    implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 sourceSets {

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.4.31'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.4.31'
-    id 'application'
+    id "org.jetbrains.kotlin.jvm" version System.env.KOTLIN_VERSION
+    id "org.jetbrains.kotlin.plugin.serialization" version System.env.KOTLIN_VERSION
+    id "application"
 }
 
 repositories {
@@ -21,9 +21,9 @@ dependencies {
 }
 
 sourceSets {
-    main.kotlin.srcDirs += '.'
+    main.kotlin.srcDirs += "."
 }
 
 application {
-    mainClassName = 'MainKt'
+    mainClassName = "MainKt"
 }

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.5.0-M1'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.31'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.4.31'
     id 'application'
 }
 
@@ -13,7 +14,10 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$System.env.JACKSON_VERSION"
     implementation "mysql:mysql-connector-java:$System.env.MYSQL_CONNECTOR_JAVA_VERSION"
     implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable"
+    implementation "org.jetbrains.kotlin:kotlin-serialization"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0"
 }
 
 sourceSets {

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable"
     implementation "org.jetbrains.kotlin:kotlin-serialization"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0"
 }
 

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version System.env.KOTLIN_VERSION
-    id "org.jetbrains.kotlin.plugin.serialization" version System.env.KOTLIN_VERSION
-    id "application"
+    id 'org.jetbrains.kotlin.jvm' version '1.4.31'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.4.31'
+    id 'application'
 }
 
 repositories {
@@ -21,9 +21,9 @@ dependencies {
 }
 
 sourceSets {
-    main.kotlin.srcDirs += "."
+    main.kotlin.srcDirs += '.'
 }
 
 application {
-    mainClassName = "MainKt"
+    mainClassName = 'MainKt'
 }


### PR DESCRIPTION
The idea behind this commit was to add `kotlin-scripting-compiler-embeddable` to the list of explicit dependencies so that is loaded during the build phase and caching is applied thus enabling us to run the `gradle run` in offline mode with `--offline` flag